### PR TITLE
Update to the latest Android SDK compile version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'net.cubiclab.clipboard'
-    compileSdk 33
+    compileSdk 36
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Fixes a recent compilation error on Android, enabling compiling to the latest SDK version (version 36, referring to Android 16).

This was the log of the error:
```
Launching lib/main.dart on sdk gphone64 arm64 in debug mode...
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':clipboard:checkDebugAarMetadata'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > 14 issues were found when checking AAR metadata:

       1.  Dependency 'androidx.window:window:1.2.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :clipboard is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       2.  Dependency 'androidx.window:window-java:1.2.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :clipboard is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       3.  Dependency 'androidx.fragment:fragment:1.7.1' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :clipboard is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       4.  Dependency 'androidx.activity:activity:1.8.1' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :clipboard is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       5.  Dependency 'androidx.lifecycle:lifecycle-livedata-core-ktx:2.7.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :clipboard is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       6.  Dependency 'androidx.lifecycle:lifecycle-livedata:2.7.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :clipboard is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       7.  Dependency 'androidx.lifecycle:lifecycle-viewmodel:2.7.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :clipboard is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       8.  Dependency 'androidx.lifecycle:lifecycle-livedata-core:2.7.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :clipboard is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

       9.  Dependency 'androidx.lifecycle:lifecycle-process:2.7.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :clipboard is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

      10.  Dependency 'androidx.lifecycle:lifecycle-runtime:2.7.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :clipboard is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

      11.  Dependency 'androidx.lifecycle:lifecycle-viewmodel-savedstate:2.7.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :clipboard is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

      12.  Dependency 'androidx.core:core-ktx:1.13.1' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :clipboard is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

      13.  Dependency 'androidx.core:core:1.13.1' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :clipboard is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

      14.  Dependency 'androidx.annotation:annotation-experimental:1.4.0' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.

           :clipboard is currently compiled against android-33.

           Recommended action: Update this project to use a newer compileSdk
           of at least 34, for example 36.

           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 57s
Error: Gradle task assembleDebug failed with exit code 1

Exited (1).
```

As a side note, thank you for this amazing package!